### PR TITLE
Add support for range iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ directory can only be opened by a single `LevelDB.DB` at a time.
 ```julia
 julia> db[key] = value
 ```
-`key` and `value` are `Array{UInt8}`. 
+`key` and `value` are `Array{UInt8}`.
 
 ```julia
 julia> db[key]
@@ -85,6 +85,15 @@ julia> for (key, value) in db
        end
 ```
 Iterate over all `key => value` pairs in a `LevelDB.DB`.
+
+
+```julia
+julia> for (key, value) in db_range_iterator(db, key1, key2)
+           #do something with the key value pair
+       end
+```
+Iterate over a range between key1 and key2 (inclusive)
+
 
 ## Authors
 

--- a/src/LevelDB.jl
+++ b/src/LevelDB.jl
@@ -295,23 +295,19 @@ mutable struct RangeIterator <: AbstractIterator
 end
 
 
-mutable struct DBRangeView
+mutable struct RangeView
     db :: DB
     key_start::Vector{UInt8}
     key_end::Vector{UInt8}
 end
 
-Base.IteratorEltype(::DBRangeView) = Vector{UInt8}
-Base.IteratorSize(::DBRangeView) = SizeUnknown()
+Base.IteratorEltype(::RangeView) = Vector{UInt8}
+Base.IteratorSize(::RangeView) = SizeUnknown()
 
 
 is_valid(it::RangeIterator) = it.handle != C_NULL && leveldb_iter_valid(it.handle) > 0x00
 
-function db_range_iterator(db::DB, key_start::Vector{UInt8}, key_end::Vector{UInt8})
-    DBRangeView(db, key_start, key_end)
-end
-
-function Base.iterate(view::DBRangeView)
+function Base.iterate(view::RangeView)
     it = RangeIterator(
                        leveldb_create_iterator(view.db.handle, view.db.read_options),
                        view.key_start, view.key_end)
@@ -328,7 +324,7 @@ function Base.iterate(view::DBRangeView)
 end
 
 
-function Base.iterate(view::DBRangeView, it::RangeIterator)
+function Base.iterate(view::RangeView, it::RangeIterator)
     if is_valid(it)
         # key is past the range?
         kv = get_key_val(it)

--- a/src/LevelDB.jl
+++ b/src/LevelDB.jl
@@ -216,9 +216,12 @@ end
 
 # This needs to be mutable, because handle == C_NULL is used to avoid double
 # free
-mutable struct Iterator
+abstract type AbstractIterator end
+
+mutable struct Iterator <: AbstractIterator
     handle :: Ptr{leveldb_iterator_t}
 end
+
 
 function Iterator(db::DB)
     Iterator(leveldb_create_iterator(db.handle, db.read_options))
@@ -230,11 +233,11 @@ Base.IteratorSize(::DB) = SizeUnknown()
 Base.seekstart(it::Iterator) = leveldb_iter_seek_to_first(it.handle)
 # Base.seekend(it::Iterator) = leveldb_iter_seek_to_last(it.handle)
 
-Base.close(it::Iterator) = @destroy_if_not_null leveldb_iter_destroy it.handle
+Base.close(it::AbstractIterator) = @destroy_if_not_null leveldb_iter_destroy it.handle
 
-is_valid(it::Iterator) = it.handle != C_NULL && leveldb_iter_valid(it.handle) > 0x00
+is_valid(it::AbstractIterator) = it.handle != C_NULL && leveldb_iter_valid(it.handle) > 0x00
 
-function get_key_val(it::Iterator)
+function get_key_val(it::AbstractIterator)
 
     # key
     key_size = Ref{Csize_t}(0)
@@ -280,5 +283,66 @@ function Base.iterate(db::DB, it::Iterator)
         return nothing
     end
 end
+
+
+####################################################
+# iterator that iterates over a range of keys of the DB
+###
+mutable struct RangeIterator <: AbstractIterator
+    handle :: Ptr{leveldb_iterator_t}
+    key_start::Vector{UInt8}
+    key_end::Vector{UInt8}
+end
+
+
+mutable struct DBRangeView
+    db :: DB
+    key_start::Vector{UInt8}
+    key_end::Vector{UInt8}
+end
+
+Base.IteratorEltype(::DBRangeView) = Vector{UInt8}
+Base.IteratorSize(::DBRangeView) = SizeUnknown()
+
+
+is_valid(it::RangeIterator) = it.handle != C_NULL && leveldb_iter_valid(it.handle) > 0x00
+
+function db_range_iterator(db::DB, key_start::Vector{UInt8}, key_end::Vector{UInt8})
+    DBRangeView(db, key_start, key_end)
+end
+
+function Base.iterate(view::DBRangeView)
+    it = RangeIterator(
+                       leveldb_create_iterator(view.db.handle, view.db.read_options),
+                       view.key_start, view.key_end)
+
+    leveldb_iter_seek(it.handle, pointer(it.key_start), length(it.key_start))
+    if is_valid(it)
+        kv = get_key_val(it)
+        leveldb_iter_next(it.handle)
+        return kv, it
+    else
+        close(it)
+        return nothing
+    end
+end
+
+
+function Base.iterate(view::DBRangeView, it::RangeIterator)
+    if is_valid(it)
+        # key is past the range?
+        kv = get_key_val(it)
+        if kv[1] > it.key_end
+            close(it)
+            return nothing
+        else
+            leveldb_iter_next(it.handle)
+            return  kv, it
+        end
+    else
+        return nothing
+    end
+end
+
 
 end # module LevelDB

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,7 +97,7 @@ end
     db[keys(d)] = values(d)
     n = 0
     # Test a range iterator that begins with the second item in DB
-    iter = LevelDB.db_range_iterator(db, [0xb, 0xb], [0xd])
+    iter = LevelDB.RangeView(db, [0xb, 0xb], [0xd])
     for (k, v) in iter
         if n == 0
             @test v == [0x2]
@@ -112,7 +112,7 @@ end
 
     # Test a range iterator that begins with a non-existing  item in DB
     n = 0
-    iter = LevelDB.db_range_iterator(db, [0xb, 0xa], [0xc, 0xd])
+    iter = LevelDB.RangeView(db, [0xb, 0xa], [0xc, 0xd])
     for (k, v) in iter
         if n == 0
             @test v == [0x2]


### PR DESCRIPTION
Now it's possible to iterate over a subset of keys (range of keys):

    iter = LevelDB.db_range_iterator(db, [0xb, 0xa], [0xc, 0xd])
    for (k, v) in iter:
        ...